### PR TITLE
Workflow with auto-commit on schedule

### DIFF
--- a/.github/workflows/generate-report.yaml
+++ b/.github/workflows/generate-report.yaml
@@ -1,7 +1,6 @@
 name: "Generate report"
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       first_reward_epoch:

--- a/.github/workflows/generate-report.yaml
+++ b/.github/workflows/generate-report.yaml
@@ -9,7 +9,7 @@ on:
         type: number
 
 jobs:
-  process-staking-rewards:
+  generate-reports:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
 
   deploy-pages:
     runs-on: ubuntu-latest
-    needs: process-staking-rewards
+    needs: generate-reports
     if: github.ref == 'refs/heads/main'
     permissions:
       pages: write

--- a/.github/workflows/generate-report.yaml
+++ b/.github/workflows/generate-report.yaml
@@ -1,0 +1,77 @@
+name: "Generate report"
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      first_reward_epoch:
+        description: "Reward epoch (Last epoch if of-four)"
+        type: number
+
+jobs:
+  process-staking-rewards:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+    - name: Install jq
+      run: sudo apt update -y && sudo apt install jq moreutils -y
+    - name: Install node modules
+      run: yarn install --frozen-lockfile
+    - name: Calculate epoch vars
+      run: |
+        export REWARD_EPOCH_DEFINED="${{ github.event.inputs.first_reward_epoch }}"
+        export REWARD_EPOCH_CALCULATED="$(node .github/workflows/get-current-reward-epoch.js)"
+        export USE_REWARD_EPOCH="${REWARD_EPOCH_DEFINED:-$REWARD_EPOCH_CALCULATED}"
+        echo "USE_REWARD_EPOCH=$USE_REWARD_EPOCH" >> "$GITHUB_ENV"
+        echo "USE_FIRST_REWARD_EPOCH=$((${USE_REWARD_EPOCH} - 3))" >> "$GITHUB_ENV"
+        echo "EPOCH_OF4_if0=$(( $(( $USE_REWARD_EPOCH - 1 )) % 4 ))" >> "$GITHUB_ENV"
+
+    - name: Generate .html report for epoch ${{ env.USE_REWARD_EPOCH }}
+      run: |
+        .github/workflows/generate-report-html.sh ${USE_REWARD_EPOCH}
+    - name: Create combined report [epoch ${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}]
+      if: env.EPOCH_OF4_if0 == 0
+      run: |
+        .github/workflows/generate-report-html.sh ${{ env.USE_FIRST_REWARD_EPOCH }} ${{ env.USE_REWARD_EPOCH }}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: staking-rewards-reports
+        path: |
+          reward-report-*
+
+  deploy-pages:
+    runs-on: ubuntu-latest
+    needs: process-staking-rewards
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: staking-rewards-reports
+        path: ./pages
+    - name: Generate index.html
+      run: |
+        cd ./pages
+        echo "<ul>" >> ../index.html
+        for i in $(find ./ -type f); do echo "<li><a href=\"./$i\">$i</a></li>" >> ../index.html; done
+        echo "</ul>" >> ../index.html
+        echo "<a href=\"https://github.com/flare-foundation/reward-scripts\">flare-foundation/reward-scripts</a>" >> ../index.html
+        mv ../index.html .
+    - uses: actions/configure-pages@v3
+    - uses: actions/upload-pages-artifact@v2
+      with:
+        path: ./pages
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2
+

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -39,7 +39,7 @@ jobs:
         echo "USE_FIRST_REWARD_EPOCH=${USE_FIRST_REWARD_EPOCH}" >> "$GITHUB_ENV"
 
         echo "EPOCH_OF4_if0=$(( $(( $USE_REWARD_EPOCH - 1 )) % 4 ))" >> "$GITHUB_ENV"
-    
+
     - name: Set reward amount wei overwrite
       if: github.event.inputs.reward_amount_epoch_wei == ''
       run: jq --raw-output --monochrome-output --argjson amount "${{ github.event.inputs.reward_amount_epoch_wei }}" '.REWARD_AMOUNT_EPOCH_WEI = $amunt' configs/networks/flare.json | sponge configs/networks/flare.json
@@ -56,7 +56,7 @@ jobs:
         jq --raw-output --monochrome-output '.NUM_EPOCHS = 4' configs/networks/flare.json | sponge configs/networks/flare.json
         jq --raw-output --monochrome-output --argjson epoch "$USE_REWARD_EPOCH" '.REWARD_EPOCH = $epoch' configs/networks/flare.json | sponge configs/networks/flare.json
         yarn sum-staking-rewards
-    
+
     - name: Commit generated-files
       run: |
         git config --global user.name 'Reward scripts automation'
@@ -65,14 +65,15 @@ jobs:
         if [ "$EPOCH_OF4_if0" -eq 0 ]; then git add generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json; fi
         git commit -m "Processed staking rewards for epoch ${{ env.USE_REWARD_EPOCH }}"
         git push
-        
-
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: staking-rewards-reports
+        name: staking-rewards
         path: |
           generated-files/reward-epoch-${{ env.USE_REWARD_EPOCH }}
           generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json
 
+    - name: Trigger "generate report" workflow
+      run: gh workflow run generate-report.yaml -f first_reward_epoch=${{ env.USE_REWARD_EPOCH }}
+      

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -13,7 +13,9 @@ on:
         description: "Reward amount (in wei)"
         type: number
 
-permissions: write-all
+permissions:
+  contents: write
+  actions: write
 
 jobs:
   process-staking-rewards:

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -56,6 +56,7 @@ jobs:
         git config --global user.email 'flare-foundation-reward-scripts-automation@users.noreply.github.com'
         git add generated-files/reward-epoch-${{ env.USE_REWARD_EPOCH }}
         if [ "$EPOCH_OF4_if0" -eq 0 ]; then git add generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json; fi
+        git commit -m "Processed staking rewards for epoch ${{ env.USE_REWARD_EPOCH }}"
         git push
         
 

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -13,8 +13,7 @@ on:
         description: "Reward amount (in wei)"
         type: number
 
-permissions:
-  contents: write
+permissions: write-all
 
 jobs:
   process-staking-rewards:
@@ -76,5 +75,5 @@ jobs:
     - name: Trigger "generate report" workflow
       env:
         GH_TOKEN: ${{ github.token }}
-      run: gh workflow run generate-report.yaml -f first_reward_epoch=${{ env.USE_REWARD_EPOCH }}
+      run: gh workflow run 77667675 -f first_reward_epoch=${{ env.USE_REWARD_EPOCH }}
       

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -23,6 +23,8 @@ jobs:
         node-version: 20
     - name: Install jq
       run: sudo apt update -y && sudo apt install jq moreutils -y
+    - name: Install node modules
+      run: yarn install --frozen-lockfile
     - name: Calculate epoch vars
       run: |
         export REWARD_EPOCH_DEFINED="${{ github.event.inputs.first_reward_epoch }}"

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -9,6 +9,9 @@ on:
       first_reward_epoch:
         description: "Reward epoch (Last epoch if of-four)"
         type: number
+      reward_amount_epoch_wei:
+        description: "Reward amount (in wei)"
+        type: number
 
 permissions:
   contents: write
@@ -36,6 +39,10 @@ jobs:
         echo "USE_FIRST_REWARD_EPOCH=${USE_FIRST_REWARD_EPOCH}" >> "$GITHUB_ENV"
 
         echo "EPOCH_OF4_if0=$(( $(( $USE_REWARD_EPOCH - 1 )) % 4 ))" >> "$GITHUB_ENV"
+    
+    - name: Set reward amount wei overwrite
+      if: github.event.inputs.reward_amount_epoch_wei == ''
+      run: jq --raw-output --monochrome-output --argjson amount "${{ github.event.inputs.reward_amount_epoch_wei }}" '.REWARD_AMOUNT_EPOCH_WEI = $amunt' configs/networks/flare.json | sponge configs/networks/flare.json
 
     - name: Process staking rewards for ${{ env.USE_REWARD_EPOCH }}
       run: |

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -81,7 +81,7 @@ jobs:
           generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json
 
     - name: Trigger "generate report" workflow
-      if: github.event.inputs.trigger_generate_report_workflow == 'true'
+      if: github.event.inputs.trigger_generate_report_workflow == 'true' or github.event.inputs.trigger_generate_report_workflow == ''
       env:
         GH_TOKEN: ${{ github.token }}
       run: gh workflow run 77667675 -f first_reward_epoch=${{ env.USE_REWARD_EPOCH }}

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -37,13 +37,13 @@ jobs:
 
         echo "EPOCH_OF4_if0=$(( $(( $USE_REWARD_EPOCH - 1 )) % 4 ))" >> "$GITHUB_ENV"
 
-    - name: Generate .html report for epoch ${{ env.USE_REWARD_EPOCH }}
+    - name: Process staking rewards for ${{ env.USE_REWARD_EPOCH }}
       run: |
         jq --raw-output --monochrome-output '.NUM_EPOCHS = 1' configs/networks/flare.json | sponge configs/networks/flare.json
         jq --raw-output --monochrome-output --argjson epoch "$USE_REWARD_EPOCH" '.REWARD_EPOCH = $epoch' configs/networks/flare.json | sponge configs/networks/flare.json
         yarn run process-staking-rewards
 
-    - name: Create combined report [epoch ${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}]
+    - name: Combine rewards for [epoch ${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}]
       if: env.EPOCH_OF4_if0 == 0
       run: |
         jq --raw-output --monochrome-output '.NUM_EPOCHS = 4' configs/networks/flare.json | sponge configs/networks/flare.json

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -75,5 +75,7 @@ jobs:
           generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json
 
     - name: Trigger "generate report" workflow
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: gh workflow run generate-report.yaml -f first_reward_epoch=${{ env.USE_REWARD_EPOCH }}
       

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -55,7 +55,7 @@ jobs:
         git config --global user.name 'Reward scripts automation'
         git config --global user.email 'flare-foundation-reward-scripts-automation@users.noreply.github.com'
         git add generated-files/reward-epoch-${{ env.USE_REWARD_EPOCH }}
-        git add generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json
+        if [ "$EPOCH_OF4_if0" -eq 0 ]; then git add generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json; fi
         git push
         
 

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -12,6 +12,12 @@ on:
       reward_amount_epoch_wei:
         description: "Reward amount (in wei)"
         type: number
+      trigger_generate_report_workflow:
+        description: "Run github pages deployment workflow"
+        type: string
+        required: true
+        default: 'true'
+
 
 permissions:
   contents: write
@@ -75,7 +81,7 @@ jobs:
           generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json
 
     - name: Trigger "generate report" workflow
+      if: github.event.inputs.trigger_generate_report_workflow == 'true'
       env:
         GH_TOKEN: ${{ github.token }}
       run: gh workflow run 77667675 -f first_reward_epoch=${{ env.USE_REWARD_EPOCH }}
-      

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -1,7 +1,6 @@
-name: "Rewards"
+name: "Calculate rewards"
 
 on:
-  push:
   schedule:
   - cron:  '0 9 * * 1' # Every Monday at 09:00 UCT
   - cron:  '0 6 * * 5' # Every Friday at 06:00 UCT
@@ -10,6 +9,9 @@ on:
       first_reward_epoch:
         description: "Reward epoch (Last epoch if of-four)"
         type: number
+
+permissions:
+  contents: write
 
 jobs:
   process-staking-rewards:
@@ -21,8 +23,6 @@ jobs:
         node-version: 20
     - name: Install jq
       run: sudo apt update -y && sudo apt install jq moreutils -y
-    - name: Install node modules
-      run: yarn install --frozen-lockfile
     - name: Calculate epoch vars
       run: |
         export REWARD_EPOCH_DEFINED="${{ github.event.inputs.first_reward_epoch }}"
@@ -40,7 +40,6 @@ jobs:
         jq --raw-output --monochrome-output '.NUM_EPOCHS = 1' configs/networks/flare.json | sponge configs/networks/flare.json
         jq --raw-output --monochrome-output --argjson epoch "$USE_REWARD_EPOCH" '.REWARD_EPOCH = $epoch' configs/networks/flare.json | sponge configs/networks/flare.json
         yarn run process-staking-rewards
-        .github/workflows/generate-report-html.sh ${USE_REWARD_EPOCH}
 
     - name: Create combined report [epoch ${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}]
       if: env.EPOCH_OF4_if0 == 0
@@ -48,8 +47,15 @@ jobs:
         jq --raw-output --monochrome-output '.NUM_EPOCHS = 4' configs/networks/flare.json | sponge configs/networks/flare.json
         jq --raw-output --monochrome-output --argjson epoch "$USE_REWARD_EPOCH" '.REWARD_EPOCH = $epoch' configs/networks/flare.json | sponge configs/networks/flare.json
         yarn sum-staking-rewards
-
-        .github/workflows/generate-report-html.sh ${{ env.USE_FIRST_REWARD_EPOCH }} ${{ env.USE_REWARD_EPOCH }}
+    
+    - name: Commit generated-files
+      run: |
+        git config --global user.name 'Reward scripts automation'
+        git config --global user.email 'flare-foundation-reward-scripts-automation@users.noreply.github.com'
+        git add generated-files/reward-epoch-${{ env.USE_REWARD_EPOCH }}
+        git add generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json
+        git push
+        
 
 
     - name: Upload artifacts
@@ -57,36 +63,6 @@ jobs:
       with:
         name: staking-rewards-reports
         path: |
-          generated-files/*
-          reward-report-*
+          generated-files/reward-epoch-${{ env.USE_REWARD_EPOCH }}
+          generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json
 
-  deploy-pages:
-    runs-on: ubuntu-latest
-    needs: process-staking-rewards
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: staking-rewards-reports
-        path: ./pages
-    - name: Generate index.html
-      run: |
-        cd ./pages
-        echo "<ul>" >> ../index.html
-        for i in $(find ./ -type f); do echo "<li><a href=\"./$i\">$i</a></li>" >> ../index.html; done
-        echo "</ul>" >> ../index.html
-        echo "<a href=\"https://github.com/flare-foundation/reward-scripts\">flare-foundation/reward-scripts</a>" >> ../index.html
-        mv ../index.html .
-    - uses: actions/configure-pages@v3
-    - uses: actions/upload-pages-artifact@v2
-      with:
-        path: ./pages
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v2

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -41,7 +41,7 @@ jobs:
         echo "EPOCH_OF4_if0=$(( $(( $USE_REWARD_EPOCH - 1 )) % 4 ))" >> "$GITHUB_ENV"
 
     - name: Set reward amount wei overwrite
-      if: github.event.inputs.reward_amount_epoch_wei == ''
+      if: github.event.inputs.reward_amount_epoch_wei != ''
       run: jq --raw-output --monochrome-output --argjson amount "${{ github.event.inputs.reward_amount_epoch_wei }}" '.REWARD_AMOUNT_EPOCH_WEI = $amunt' configs/networks/flare.json | sponge configs/networks/flare.json
 
     - name: Process staking rewards for ${{ env.USE_REWARD_EPOCH }}

--- a/.github/workflows/scheduled-commit.yaml
+++ b/.github/workflows/scheduled-commit.yaml
@@ -63,8 +63,7 @@ jobs:
         git config --global user.email 'flare-foundation-reward-scripts-automation@users.noreply.github.com'
         git add generated-files/reward-epoch-${{ env.USE_REWARD_EPOCH }}
         if [ "$EPOCH_OF4_if0" -eq 0 ]; then git add generated-files/validator-rewards/epochs-${{ env.USE_FIRST_REWARD_EPOCH }}-${{ env.USE_REWARD_EPOCH }}.json; fi
-        git commit -m "Processed staking rewards for epoch ${{ env.USE_REWARD_EPOCH }}"
-        git push
+        git commit -m "Processed staking rewards for epoch ${{ env.USE_REWARD_EPOCH }}" && git push || echo "No changes were present, failed to commit, proceeding..."
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -38,10 +38,6 @@ const BgGray = '\x1b[100m';
 export class ColorConsole extends Transport {
    instance = 0;
 
-   lastLog: string = '';
-   lastLog2: string = '';
-   duplicate = 0;
-
    mode: '' | 'sticky' | 'forgettable' = '';
 
    terminal: Terminal;
@@ -120,31 +116,7 @@ export class ColorConsole extends Transport {
             this.mode = '';
          }
 
-         if (this.lastLog === text) {
-            this.duplicate++;
-            process.stdout.write(
-               '\r' + BgGray + FgBlack + info.timestamp.substring(11, 11 + 11) + Reset + mem + ` ` + BgWhite + FgBlack + ` ${this.duplicate} ` + Reset
-            );
-         } else if (this.lastLog2 === text) {
-            this.duplicate++;
-            process.stdout.write(
-               '\r' + BgGray + FgBlack + info.timestamp.substring(11, 11 + 11) + Reset + mem + ` ` + BgWhite + FgBlack + ` ${this.duplicate}+ ` + Reset
-            );
-         } else {
-            try {
-               if (this.duplicate > 0) {
-                  console.log(``);
-               }
-               this.lastLog2 = this.lastLog;
-               this.lastLog = text;
-               this.duplicate = 0;
-
-               //            |           |
-               // "2022-01-10T13:13:07.712Z"
-
-               console.log(BgGray + FgBlack + info.timestamp.substring(11, 11 + 11) + Reset + mem + ` ` + color + processColors(text, color) + Reset);
-            } catch {}
-         }
+         console.log(BgGray + FgBlack + info.timestamp.substring(11, 11 + 11) + Reset + mem + ` ` + color + processColors(text, color) + Reset);
       }
 
       if (callback) {

--- a/src/services/CalculatingRewardsService.ts
+++ b/src/services/CalculatingRewardsService.ts
@@ -102,8 +102,9 @@ export class CalculatingRewardsService {
 		let entities = [] as Entity[];
 		let allActiveNodes = [] as ActiveNode[];
 
+		const processedNodesInterval = setInterval(() => this.logger.info(`${allActiveNodes.length} nodes processed so far`), 15000);
+
 		//// for each node check if it is eligible for rewarding, get its delegations, decide to which entity it belongs and calculate boost, total stake amount, ...
-		let numberOfProcessedNodes = 0;
 		this.logger.info(`^Rprocessing nodes data started`);
 		for (const activeNode of activeNodes) {
 			let [eligible, ftsoAddress, nonEligibilityReason, ftsoName] = await this.isEligibleForReward(activeNode, eligibleNodesUptime, ftsoAddresses, ftsoRewardManager, rewardEpoch, ftsoPerformanceForRewardWei, rps);
@@ -175,11 +176,9 @@ export class CalculatingRewardsService {
 				})
 			}
 			allActiveNodes.push(node);
-			numberOfProcessedNodes++;
-			if (numberOfProcessedNodes % 3 === 0) {
-				this.logger.info(`${numberOfProcessedNodes} nodes processed`);
-			}
 		}
+
+		clearInterval(processedNodesInterval);
 
 		this.logger.info(`^Rcalculating rewards started`);
 		// after calculating total self-bond for entities, we can check if entity is eligible for boosting and calculate overboost


### PR DESCRIPTION
Rework the GH workflow;

- split it into two workflows
- both can be manually triggered
- one runs also on schedule, after the end of each epoch, running the `process-staking-rewards` script, committing the generated files to the repository and then starting the second workflow
- second workflow generates the report and deploys it to github pages (overwriting the previous deployment)